### PR TITLE
Allow Teleport to write to s3 bucket

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -66,7 +66,6 @@ data "aws_iam_policy_document" "s3" {
       "s3:ListBucket",
       "s3:ListBucketVersions",
       "s3:ListBucketMultipartUploads",
-      "s3:AbortMultipartUpload",
     ]
     resources = ["arn:aws:s3:::${aws_s3_bucket.teleport.bucket}"]
   }
@@ -76,8 +75,9 @@ data "aws_iam_policy_document" "s3" {
       "s3:PutObject",
       "s3:GetObject",
       "s3:GetObjectVersion",
+      "s3:AbortMultipartUpload",
     ]
-    resources = ["arn:aws:s3:::${aws_s3_bucket.teleport.bucket}/records"]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.teleport.bucket}/records/*"]
   }
 }
 


### PR DESCRIPTION
Background:
Teleport couldn't write session audit logs to s3.

Changes:
Updated IAM S3 policy for Teleport

Tests:
Made IAM changes via UI and confirmed this was needed.

```
ubuntu@ip-172-16-10-93:~$ aws s3 cp text.txt s3://defcon-2023-obsidian-teleport-kxl6y/records/text.txt
upload failed: ./text.txt to s3://defcon-2023-obsidian-teleport-kxl6y/records/text.txt An error occurred (AccessDenied) when calling the PutObject operation: Access Denied


ubuntu@ip-172-16-10-93:~$ aws s3 cp text.txt s3://defcon-2023-obsidian-teleport-kxl6y/records/text.txt
upload: ./text.txt to s3://defcon-2023-obsidian-teleport-kxl6y/records/text.txt
```