### PR TITLE
refactor, feat, ci, chore

### DIFF
--- a/.github/workflows/default-bare.yml
+++ b/.github/workflows/default-bare.yml
@@ -1,0 +1,115 @@
+---
+name: default-bare
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build:
+    permissions:
+      contents: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-22.04, ubuntu-20.04]
+    env:
+      ANSIBLE_CALLBACKS_ENABLED: profile_tasks
+      ANSIBLE_EXTRA_VARS: "-e teleport_storage_backend=sqlite -e teleport_auth_type=local"
+      ANSIBLE_ROLE: blueteamvillage.btv-sec-eng-teleport-cluster
+      ANSIBLE_ROLE_PATH: btv-sec-eng-teleport-cluster/ansible/roles/teleport-cluster
+      ANSIBLE_PLAYBOOK: test/integration/default/default.yml
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install ansible-lint flake8 yamllint
+          which ansible
+          pip3 install ansible
+          pip3 show ansible
+          ansible --version
+          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE_PATH
+          ln -s $GITHUB_WORKSPACE/$ANSIBLE_ROLE_PATH $GITHUB_WORKSPACE/$ANSIBLE_ROLE_PATH/../$ANSIBLE_ROLE
+          { echo '[defaults]'; echo 'callbacks_enabled = profile_tasks, timer'; echo 'roles_path = ../'; echo 'ansible_python_interpreter: /usr/bin/python3'; } >> ansible.cfg
+      - name: Environment
+        run: |
+          set -x
+          pwd
+          env
+          find -ls
+      - name: run test
+        run: |
+          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE_PATH && ansible-playbook -i localhost, --connection=local --become -vvv $ANSIBLE_PLAYBOOK ${ANSIBLE_EXTRA_VARS}
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+      - name: idempotency run
+        run: |
+          cd $GITHUB_WORKSPACE/$ANSIBLE_ROLE_PATH && ansible-playbook -i localhost, --connection=local --become -vvv $ANSIBLE_PLAYBOOK ${ANSIBLE_EXTRA_VARS} | tee /tmp/idempotency.log | grep -q 'changed=0.*failed=0'  && (echo 'Idempotence test: pass' && exit 0)  || (echo 'Idempotence test: fail' && cat /tmp/idempotency.log && exit 0)
+      - name: On failure
+        run: |
+          systemctl -l --no-pager status
+          systemctl -l --no-pager --failed
+          ls -l /usr/bin/ | egrep '(python|pip|ansible)'
+          pip freeze
+          pip3 freeze
+          ip addr
+          cat /etc/resolv.conf
+          host www.google.com
+          ping -c 1 www.google.com || true
+          ping -c 1 8.8.8.8 || true
+        if: ${{ failure() }}
+        continue-on-error: true
+      - name: After script - ansible setup
+        run: |
+          ansible -i inventory --connection=local -m setup localhost
+        if: ${{ always() }}
+        continue-on-error: true
+      - name: After script - systemd
+        run: |
+          systemctl -l --no-pager status teleport || true
+          systemd-analyze --no-pager security || true
+        if: ${{ always() }}
+        continue-on-error: true
+      - name: After script - network
+        run: |
+          sudo ss -tunap
+        if: ${{ always() }}
+        continue-on-error: true
+      - name: After script - etc
+        run: |
+          set -x
+          sudo cat /etc/teleport.yaml
+        if: ${{ always() }}
+        continue-on-error: true
+      - name: After script - tctl
+        run: |
+          set -x
+          sudo tctl status
+          sudo tctl users ls
+          sudo tctl nodes ls
+          sudo tctl inventory ls
+        if: ${{ always() }}
+        continue-on-error: true
+      - name: After script - logs
+        run: |
+          set -x
+          sudo tail -100 /var/lib/teleport/log/events.log
+        if: ${{ always() }}
+        continue-on-error: true
+      - name: After script - journalctl
+        run: |
+          journalctl -xeu teleport -l --no-pager
+        if: ${{ always() }}
+        continue-on-error: true

--- a/.github/workflows/default-bare.yml
+++ b/.github/workflows/default-bare.yml
@@ -87,6 +87,11 @@ jobs:
           sudo ss -tunap
         if: ${{ always() }}
         continue-on-error: true
+      - name: After script - iptables
+        run: |
+          sudo iptables -L -vn
+        if: ${{ always() }}
+        continue-on-error: true
       - name: After script - etc
         run: |
           set -x
@@ -100,6 +105,13 @@ jobs:
           sudo tctl users ls
           sudo tctl nodes ls
           sudo tctl inventory ls
+        if: ${{ always() }}
+        continue-on-error: true
+      - name: After script - curl
+        run: |
+          set -x
+          hostname
+          curl -v https://`hostname` || true
         if: ${{ always() }}
         continue-on-error: true
       - name: After script - logs

--- a/.github/workflows/default-bare.yml
+++ b/.github/workflows/default-bare.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-20.04]
     env:
       ANSIBLE_CALLBACKS_ENABLED: profile_tasks
-      ANSIBLE_EXTRA_VARS: "-e teleport_storage_backend=sqlite -e teleport_auth_type=local -e teleport_reboot_enabled=false"
+      ANSIBLE_EXTRA_VARS: "-e teleport_storage_backend=sqlite -e teleport_auth_type=local -e teleport_reboot_enabled=false -e teleport_auth_online=false"
       ANSIBLE_ROLE: blueteamvillage.btv-sec-eng-teleport-cluster
       ANSIBLE_ROLE_PATH: ansible/roles/teleport-cluster
       ANSIBLE_PLAYBOOK: tests/test.yml

--- a/.github/workflows/default-bare.yml
+++ b/.github/workflows/default-bare.yml
@@ -22,8 +22,8 @@ jobs:
       ANSIBLE_CALLBACKS_ENABLED: profile_tasks
       ANSIBLE_EXTRA_VARS: "-e teleport_storage_backend=sqlite -e teleport_auth_type=local"
       ANSIBLE_ROLE: blueteamvillage.btv-sec-eng-teleport-cluster
-      ANSIBLE_ROLE_PATH: btv-sec-eng-teleport-cluster/ansible/roles/teleport-cluster
-      ANSIBLE_PLAYBOOK: test/integration/default/default.yml
+      ANSIBLE_ROLE_PATH: ansible/roles/teleport-cluster
+      ANSIBLE_PLAYBOOK: tests/test.yml
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/default-bare.yml
+++ b/.github/workflows/default-bare.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-20.04]
     env:
       ANSIBLE_CALLBACKS_ENABLED: profile_tasks
-      ANSIBLE_EXTRA_VARS: "-e teleport_storage_backend=sqlite -e teleport_auth_type=local"
+      ANSIBLE_EXTRA_VARS: "-e teleport_storage_backend=sqlite -e teleport_auth_type=local -e teleport_reboot_enabled=false"
       ANSIBLE_ROLE: blueteamvillage.btv-sec-eng-teleport-cluster
       ANSIBLE_ROLE_PATH: ansible/roles/teleport-cluster
       ANSIBLE_PLAYBOOK: tests/test.yml

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -58,5 +58,9 @@ jobs:
         run: go install github.com/aquasecurity/tfsec/cmd/tfsec@latest
 
       ########################### pre-commit ###########################
+      - name: Ansible requirements
+        run: ansible-galaxy collection install -r ansible/roles/teleport-cluster/requirements.yml
+      - name: Symlink role name
+        run: ln -s ../../teleport-cluster ansible/roles/teleport-cluster/tests/blueteamvillage.btv-sec-eng-teleport-cluster
       - name: pre-commit modules
         run: pre-commit run --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,31 +22,31 @@ repos:
 
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.7.0
     hooks:
       - id: black
 
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         args: ['--max-line-length=88']
 
 
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.16.0b0
+    rev: v3.0.0a6
     hooks:
       - id: pylint
 
 
   - repo: https://github.com/ansible/ansible-lint
-    rev: v6.11.0
+    rev: v6.17.2
     hooks:
       - id: ansible-lint
         files: ^ansible/
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.81.2
     hooks:
       - id: terraform_fmt

--- a/ansible/roles/teleport-cluster/README.md
+++ b/ansible/roles/teleport-cluster/README.md
@@ -1,7 +1,7 @@
-Role Name
+Teleport Cluster role
 =========
 
-A brief description of the role goes here.
+This role will setup a [Teleport Cluster](https://goteleport.com/).
 
 Requirements
 ------------
@@ -25,7 +25,14 @@ Including an example of how to use your role (for instance, with variables passe
 
     - hosts: servers
       roles:
-         - { role: username.rolename, x: 42 }
+         - { role: blueteamvillage.btv-sec-eng-teleport-cluster, x: 42 }
+
+FAQ
+---
+
+* Use `tctl users reset <username> to reset password/get user invite link`
+* In Azure, teleport will automatically recover VM tags as teleport labels
+* Once cluster is setup, you can use [mdsketch.teleport](https://github.com/mdsketch/ansible-teleport) to add servers to it. Teleport cluster must have network connectivity to nodes services like port 3022 for ssh.
 
 License
 -------

--- a/ansible/roles/teleport-cluster/defaults/main.yml
+++ b/ansible/roles/teleport-cluster/defaults/main.yml
@@ -25,6 +25,21 @@ teleport_storage_azureblob_domain: account-name.core.blob.windows.net
 
 # teleport_storage_backend: sqlite
 
+## Authentication
+# teleport_auth_type: local
+# mfa requires webauthn configuration
+teleport_auth_local_mfa: true
+# You can't provide password, users must be shared invite link and fill in.
+# Use `tctl users reset` to create new link.
+teleport_auth_local_users:
+  - username: joe
+    logins:
+      - joe
+      - root
+    roles:
+      - access
+      - editor
+
 # GitHub SSO
 teleport_auth_type: github
 github_org_name:

--- a/ansible/roles/teleport-cluster/defaults/main.yml
+++ b/ansible/roles/teleport-cluster/defaults/main.yml
@@ -51,6 +51,9 @@ github_redirect_url:
 github_admin_team:
 github_workshop_contributors:
 
+# Disable if CI without public fqdn
+teleport_auth_online: true
+
 ######################################## teleport ########################################
 teleport_version: 13
 teleport_gpg_key: "https://apt.releases.teleport.dev/gpg"

--- a/ansible/roles/teleport-cluster/defaults/main.yml
+++ b/ansible/roles/teleport-cluster/defaults/main.yml
@@ -6,6 +6,7 @@ teleport_fqdn: "{{ ansible_fqdn }}"
 # you won't be able to connect to web interface.
 teleport_acme_email: "admin@{{ teleport_fqdn }}"
 timezone: UTC
+teleport_reboot_enabled: true
 
 # roles templates without j2 suffix
 teleport_roles_templates:

--- a/ansible/roles/teleport-cluster/defaults/main.yml
+++ b/ansible/roles/teleport-cluster/defaults/main.yml
@@ -50,7 +50,7 @@ github_admin_team:
 github_workshop_contributors:
 
 ######################################## teleport ########################################
-teleport_version: 12
+teleport_version: 13
 teleport_gpg_key: "https://apt.releases.teleport.dev/gpg"
 teleport_apt_repo: "deb https://apt.releases.teleport.dev/ubuntu {{ ansible_distribution_release }} stable/v{{ teleport_version }}"
 

--- a/ansible/roles/teleport-cluster/defaults/main.yml
+++ b/ansible/roles/teleport-cluster/defaults/main.yml
@@ -18,6 +18,13 @@ teleport_bucket_name:
 teleport_dynamodb_table:
 teleport_dynamodb_events_table:
 
+# teleport_storage_backend: azureblob
+# permissions: rwd
+# recommended to use managed identity
+teleport_storage_azureblob_domain: account-name.core.blob.windows.net
+
+# teleport_storage_backend: sqlite
+
 # GitHub SSO
 teleport_auth_type: github
 github_org_name:

--- a/ansible/roles/teleport-cluster/defaults/main.yml
+++ b/ansible/roles/teleport-cluster/defaults/main.yml
@@ -1,2 +1,42 @@
 ---
 # defaults file for ansible/teleport-cluster
+
+teleport_fqdn: "{{ ansible_fqdn }}"
+# must be valid else letsencrypt certificate won't be auto provisioned and
+# you won't be able to connect to web interface.
+teleport_acme_email: "admin@{{ teleport_fqdn }}"
+
+# roles templates without j2 suffix
+teleport_roles_templates:
+  - sec_infra_role.yaml
+  - workshop_contributors_role.yaml
+
+## https://goteleport.com/docs/reference/backends/
+teleport_storage_backend: dynamodb
+primary_region:
+teleport_bucket_name:
+teleport_dynamodb_table:
+teleport_dynamodb_events_table:
+
+# GitHub SSO
+teleport_auth_type: github
+github_org_name:
+github_client_id:
+github_client_secret:
+github_redirect_url:
+github_admin_team:
+github_workshop_contributors:
+
+######################################## teleport ########################################
+teleport_version: 12
+teleport_gpg_key: "https://apt.releases.teleport.dev/gpg"
+teleport_apt_repo: "deb https://apt.releases.teleport.dev/ubuntu {{ ansible_distribution_release }} stable/v{{ teleport_version }}"
+
+######################################## proxy_service ########################################
+teleport_proxy_service_port: 443
+
+######################################## ssh_service ########################################
+teleport_ssh_service_port: 3022
+
+######################################## auth_service ########################################
+teleport_auth_service_port: 3025

--- a/ansible/roles/teleport-cluster/defaults/main.yml
+++ b/ansible/roles/teleport-cluster/defaults/main.yml
@@ -5,6 +5,7 @@ teleport_fqdn: "{{ ansible_fqdn }}"
 # must be valid else letsencrypt certificate won't be auto provisioned and
 # you won't be able to connect to web interface.
 teleport_acme_email: "admin@{{ teleport_fqdn }}"
+timezone: UTC
 
 # roles templates without j2 suffix
 teleport_roles_templates:

--- a/ansible/roles/teleport-cluster/meta/main.yml
+++ b/ansible/roles/teleport-cluster/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
   issue_tracker_url: https://github.com/blueteamvillage/btv-teleport-single-cluster/issues
   license: MIT
 
-  min_ansible_version: 2.1
+  min_ansible_version: '2.1'
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
@@ -20,7 +20,7 @@ galaxy_info:
   # https://galaxy.ansible.com/api/v1/platforms/
   #
   platforms:
-    - name: ubuntu
+    - name: Ubuntu
       versions:
         - jammy
 

--- a/ansible/roles/teleport-cluster/requirements.yml
+++ b/ansible/roles/teleport-cluster/requirements.yml
@@ -1,0 +1,5 @@
+---
+# ansible-galaxy collection install -r requirements-collections.yml
+
+collections:
+  - community.general

--- a/ansible/roles/teleport-cluster/tasks/init_linux.yml
+++ b/ansible/roles/teleport-cluster/tasks/init_linux.yml
@@ -11,6 +11,7 @@
 - name: Run the equivalent of "apt-get update" as a separate step
   ansible.builtin.apt:
     update_cache: true
+    cache_valid_time: "{{ teleport_apt_cache_valid_time | default(3600) }}"
 
 - name: Update all packages to their latest version
   ansible.builtin.apt:

--- a/ansible/roles/teleport-cluster/tasks/init_linux.yml
+++ b/ansible/roles/teleport-cluster/tasks/init_linux.yml
@@ -29,7 +29,9 @@
 - name: Reboot a slow machine that might have lots of updates to apply
   ansible.builtin.reboot:
     reboot_timeout: 3600
-  when: reboot_required_file.stat.exists
+  when:
+    - reboot_required_file.stat.exists
+    - teleport_reboot_enabled | bool
 
 ####################################################################
 # Install software

--- a/ansible/roles/teleport-cluster/tasks/setup_teleport.yml
+++ b/ansible/roles/teleport-cluster/tasks/setup_teleport.yml
@@ -44,53 +44,54 @@
 ######################################################
 # Setup roles
 ######################################################
-- name: Copy sec_infra role
+- name: Copy role templates
   ansible.builtin.template:
-    src: "templates/sec_infra_role.yaml.j2"
-    dest: "/etc/teleport.d/sec_infra_role.yaml"
+    src: "{{ item }}.j2"
+    dest: "/etc/teleport.d/{{ item | basename }}"
     owner: root
     group: root
     mode: 0400
+  loop: "{{ teleport_roles_templates }}"
 
-- name: Create sec_infra role
-  ansible.builtin.command: "tctl create -f /etc/teleport.d/sec_infra_role.yaml"
-
-- name: Copy workshop_contributor role
-  ansible.builtin.template:
-    src: "templates/workshop_contributors_role.yaml.j2"
-    dest: "/etc/teleport.d/workshop_contributors_role.yaml"
-    owner: root
-    group: root
-    mode: 0600
-
-- name: Create sec_infra role
-  ansible.builtin.command: "tctl create -f /etc/teleport.d/workshop_contributors_role.yaml"
+- name: Create role with tctl
+  ansible.builtin.command: "tctl create -f /etc/teleport.d/{{ item | basename }}"
+  register: tctlrole
+  changed_when:
+    - "'has been created' in tctlrole.stdout"
+  loop: "{{ teleport_roles_templates }}"
 
 ######################################################
 # Setup Github SSO
 # https://goteleport.com/docs/access-controls/sso/github-sso/
 ######################################################
-- name: Copy Github config
-  ansible.builtin.template:
-    src: "templates/github.yaml.j2"
-    dest: "/etc/teleport.d/github.yaml"
-    owner: root
-    group: root
-    mode: 0600
+- name: Github SSO
+  when:
+    - teleport_auth_type == 'github'
+    - github_org_name|string
+    - github_client_id|string
+    - github_client_secret|string
+  block:
+    - name: Copy Github config
+      ansible.builtin.template:
+        src: "templates/github.yaml.j2"
+        dest: "/etc/teleport.d/github.yaml"
+        owner: root
+        group: root
+        mode: 0600
 
-- name: Create Github connector
-  ansible.builtin.command: "tctl create -f /etc/teleport.d/github.yaml"
+    - name: Create Github connector
+      ansible.builtin.command: "tctl create -f /etc/teleport.d/github.yaml"
 
-- name: Copy cap config
-  ansible.builtin.template:
-    src: "templates/cap.yaml.j2"
-    dest: "/etc/teleport.d/cap.yaml"
-    owner: root
-    group: root
-    mode: 0600
+    - name: Copy cap config
+      ansible.builtin.template:
+        src: "templates/cap.yaml.j2"
+        dest: "/etc/teleport.d/cap.yaml"
+        owner: root
+        group: root
+        mode: 0600
 
-- name: Create cluster auth preferences
-  ansible.builtin.command: "tctl create -f /etc/teleport.d/cap.yaml"
+    - name: Create cluster auth preferences
+      ansible.builtin.command: "tctl create -f /etc/teleport.d/cap.yaml"
 
 ######################################################
 # Healthcheck Teleport

--- a/ansible/roles/teleport-cluster/tasks/setup_teleport.yml
+++ b/ansible/roles/teleport-cluster/tasks/setup_teleport.yml
@@ -96,8 +96,17 @@
 ######################################################
 # Healthcheck Teleport
 ######################################################
-- name: Teleport Health Check
+- name: Teleport Health Check - local port
   ansible.builtin.wait_for:
-    port: [443, 3022, 3025]
+    port: "{{ item }}"
     delay: 10
     timeout: 300
+  loop: [443, 3022, 3025]
+
+- name: Teleport Health Check - web fqdn
+  ansible.builtin.wait_for:
+    host: "{{ teleport_fqdn }}"
+    port: "{{ item }}"
+    delay: 10
+    timeout: 300
+  loop: [443]

--- a/ansible/roles/teleport-cluster/tasks/setup_teleport.yml
+++ b/ansible/roles/teleport-cluster/tasks/setup_teleport.yml
@@ -61,6 +61,25 @@
   loop: "{{ teleport_roles_templates }}"
 
 ######################################################
+# Setup local users if local authentication
+# https://goteleport.com/docs/management/admin/users/#adding-local-users
+######################################################
+- name: Local Authentication
+  when:
+    - teleport_auth_type == 'local'
+  block:
+    - name: Create local users with tctl
+      ansible.builtin.command: "tctl users add {{ item.username }} --logins={{ item.logins | join(',') }} --roles={{ item.roles | join(',') }}"
+      register: tctlusers
+      changed_when:
+        - tctlusers.rc == 0
+        - "'already registered' not in tctlusers.stderr"
+      failed_when:
+        - tctlusers.rc != 0
+        - "'already registered' not in tctlusers.stderr"
+      loop: "{{ teleport_auth_local_users }}"
+
+######################################################
 # Setup Github SSO
 # https://goteleport.com/docs/access-controls/sso/github-sso/
 ######################################################

--- a/ansible/roles/teleport-cluster/tasks/setup_teleport.yml
+++ b/ansible/roles/teleport-cluster/tasks/setup_teleport.yml
@@ -33,7 +33,7 @@
     dest: "/etc/teleport.yaml"
     owner: root
     group: root
-    mode: 0600
+    mode: '0600'
 
 - name: Start Teleport
   ansible.builtin.service:
@@ -50,7 +50,7 @@
     dest: "/etc/teleport.d/{{ item | basename }}"
     owner: root
     group: root
-    mode: 0400
+    mode: '0400'
   loop: "{{ teleport_roles_templates }}"
 
 - name: Create role with tctl
@@ -96,7 +96,7 @@
         dest: "/etc/teleport.d/github.yaml"
         owner: root
         group: root
-        mode: 0600
+        mode: '0600'
 
     - name: Create Github connector
       ansible.builtin.command: "tctl create -f /etc/teleport.d/github.yaml"
@@ -107,7 +107,7 @@
         dest: "/etc/teleport.d/cap.yaml"
         owner: root
         group: root
-        mode: 0600
+        mode: '0600'
 
     - name: Create cluster auth preferences
       ansible.builtin.command: "tctl create -f /etc/teleport.d/cap.yaml"

--- a/ansible/roles/teleport-cluster/tasks/setup_teleport.yml
+++ b/ansible/roles/teleport-cluster/tasks/setup_teleport.yml
@@ -63,6 +63,8 @@
   loop: "{{ teleport_roles_templates }}"
   loop_control:
     loop_var: teleport_cluster_item
+  when:
+    - teleport_auth_online | bool
 
 ######################################################
 # Setup local users if local authentication
@@ -71,6 +73,7 @@
 - name: Local Authentication
   when:
     - teleport_auth_type == 'local'
+    - teleport_auth_online | bool
   block:
     - name: Create local users with tctl
       ansible.builtin.command: |
@@ -109,6 +112,8 @@
 
     - name: Create Github connector
       ansible.builtin.command: "tctl create -f /etc/teleport.d/github.yaml"
+      when:
+        - teleport_auth_online | bool
 
     - name: Copy cap config
       ansible.builtin.template:
@@ -120,6 +125,8 @@
 
     - name: Create cluster auth preferences
       ansible.builtin.command: "tctl create -f /etc/teleport.d/cap.yaml"
+      when:
+        - teleport_auth_online | bool
 
 ######################################################
 # Healthcheck Teleport
@@ -142,3 +149,5 @@
   loop: [443]
   loop_control:
     loop_var: teleport_cluster_item
+  when:
+    - teleport_auth_online | bool

--- a/ansible/roles/teleport-cluster/tasks/setup_teleport.yml
+++ b/ansible/roles/teleport-cluster/tasks/setup_teleport.yml
@@ -46,19 +46,23 @@
 ######################################################
 - name: Copy role templates
   ansible.builtin.template:
-    src: "{{ item }}.j2"
-    dest: "/etc/teleport.d/{{ item | basename }}"
+    src: "{{ teleport_cluster_item }}.j2"
+    dest: "/etc/teleport.d/{{ teleport_cluster_item | basename }}"
     owner: root
     group: root
     mode: '0400'
   loop: "{{ teleport_roles_templates }}"
+  loop_control:
+    loop_var: teleport_cluster_item
 
 - name: Create role with tctl
-  ansible.builtin.command: "tctl create -f /etc/teleport.d/{{ item | basename }}"
+  ansible.builtin.command: "tctl create -f /etc/teleport.d/{{ teleport_cluster_item | basename }}"
   register: tctlrole
   changed_when:
     - "'has been created' in tctlrole.stdout"
   loop: "{{ teleport_roles_templates }}"
+  loop_control:
+    loop_var: teleport_cluster_item
 
 ######################################################
 # Setup local users if local authentication
@@ -69,7 +73,10 @@
     - teleport_auth_type == 'local'
   block:
     - name: Create local users with tctl
-      ansible.builtin.command: "tctl users add {{ item.username }} --logins={{ item.logins | join(',') }} --roles={{ item.roles | join(',') }}"
+      ansible.builtin.command: |
+        tctl users add {{ teleport_cluster_item.username }}
+          --logins={{ teleport_cluster_item.logins | join(',') }}
+          --roles={{ teleport_cluster_item.roles | join(',') }}
       register: tctlusers
       changed_when:
         - tctlusers.rc == 0
@@ -78,6 +85,8 @@
         - tctlusers.rc != 0
         - "'already registered' not in tctlusers.stderr"
       loop: "{{ teleport_auth_local_users }}"
+      loop_control:
+        loop_var: teleport_cluster_item
 
 ######################################################
 # Setup Github SSO
@@ -117,15 +126,19 @@
 ######################################################
 - name: Teleport Health Check - local port
   ansible.builtin.wait_for:
-    port: "{{ item }}"
+    port: "{{ teleport_cluster_item }}"
     delay: 10
     timeout: 300
   loop: [443, 3022, 3025]
+  loop_control:
+    loop_var: teleport_cluster_item
 
 - name: Teleport Health Check - web fqdn
   ansible.builtin.wait_for:
     host: "{{ teleport_fqdn }}"
-    port: "{{ item }}"
+    port: "{{ teleport_cluster_item }}"
     delay: 10
     timeout: 300
   loop: [443]
+  loop_control:
+    loop_var: teleport_cluster_item

--- a/ansible/roles/teleport-cluster/templates/teleport.yaml.j2
+++ b/ansible/roles/teleport-cluster/templates/teleport.yaml.j2
@@ -29,6 +29,14 @@ auth_service:
   listen_addr: 0.0.0.0:{{ teleport_auth_service_port }}
   cluster_name: {{ teleport_fqdn }}
   proxy_listener_mode: multiplex
+{% if teleport_auth_type == 'local' %}
+  authentication:
+    type: local
+    # require_session_mfa: false
+    second_factor: "{{ teleport_auth_local_mfa | ternary('on', 'off') }}"
+    webauthn:
+      rp_id: {{ teleport_fqdn }}
+{% endif %}
 ssh_service:
   enabled: "yes"
   commands:

--- a/ansible/roles/teleport-cluster/templates/teleport.yaml.j2
+++ b/ansible/roles/teleport-cluster/templates/teleport.yaml.j2
@@ -18,6 +18,11 @@ teleport:
     audit_events_uri:  ['dynamodb://{{ teleport_dynamodb_events_table }}', 'file:///var/lib/teleport/audit/events', 'stdout://']
     audit_sessions_uri: "s3://{{ teleport_bucket_name }}/records"
     audit_retention_period: 90d
+{% elif teleport_storage_backend == 'azureblog' %}
+    audit_sessions_uri: azblob://{{ teleport_storage_azureblob_domain }}
+{% elif teleport_storage_backend == 'sqlite' %}
+    type: sqlite
+    sync: NORMAL
 {% endif %}
 auth_service:
   enabled: "yes"

--- a/ansible/roles/teleport-cluster/templates/teleport.yaml.j2
+++ b/ansible/roles/teleport-cluster/templates/teleport.yaml.j2
@@ -10,6 +10,7 @@ teleport:
   ca_pin: ""
   diag_addr: ""
   storage:
+{% if teleport_storage_backend == 'dynamodb' %}
     type: dynamodb
     region: "{{ primary_region }}"
     # Name of the DynamoDB table. If it does not exist, Teleport will create it.
@@ -17,6 +18,7 @@ teleport:
     audit_events_uri:  ['dynamodb://{{ teleport_dynamodb_events_table }}', 'file:///var/lib/teleport/audit/events', 'stdout://']
     audit_sessions_uri: "s3://{{ teleport_bucket_name }}/records"
     audit_retention_period: 90d
+{% endif %}
 auth_service:
   enabled: "yes"
   listen_addr: 0.0.0.0:{{ teleport_auth_service_port }}
@@ -35,6 +37,6 @@ proxy_service:
   https_keypairs: []
   acme:
     enabled: "yes"
-    email: admin@{{ teleport_fqdn }}
+    email: {{ teleport_acme_email }}
 app_service:
   enabled: "yes"

--- a/ansible/roles/teleport-cluster/tests/test.yml
+++ b/ansible/roles/teleport-cluster/tests/test.yml
@@ -2,4 +2,5 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - ansible/teleport-cluster
+    # - ansible/teleport-cluster
+    - blueteamvillage.btv-sec-eng-teleport-cluster

--- a/ansible/roles/teleport-cluster/tests/test.yml
+++ b/ansible/roles/teleport-cluster/tests/test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Test play
+  hosts: localhost
   remote_user: root
   roles:
     # - ansible/teleport-cluster

--- a/ansible/roles/teleport-cluster/vars/main.yml
+++ b/ansible/roles/teleport-cluster/vars/main.yml
@@ -1,16 +1,2 @@
 ---
 # vars file for ansible/teleport-cluster
-
-######################################## teleport ########################################
-teleport_version: 12
-teleport_gpg_key: "https://apt.releases.teleport.dev/gpg"
-teleport_apt_repo: "deb https://apt.releases.teleport.dev/ubuntu {{ ansible_distribution_release }} stable/v{{ teleport_version }}"
-
-######################################## proxy_service ########################################
-teleport_proxy_service_port: 443
-
-######################################## ssh_service ########################################
-teleport_ssh_service_port: 3022
-
-######################################## auth_service ########################################
-teleport_auth_service_port: 3025


### PR DESCRIPTION
This does not change existing defaults (except teleport version) but allow more options along CI regular testing

* refactor: move vars to defaults, more defaults variables
* feat: alternate setting for backend (azureblob, sqlite)
* feat: alternate setting auth local+users
* ci: add default-bare github workflow
* chore: ansible-lint
* up teleport from v12 to v13